### PR TITLE
Fix path trace usage

### DIFF
--- a/nextbox_ui_plugin/__init__.py
+++ b/nextbox_ui_plugin/__init__.py
@@ -4,7 +4,7 @@ class NextBoxUIConfig(PluginConfig):
     name = 'nextbox_ui_plugin'
     verbose_name = 'NextBox UI'
     description = 'Test'
-    version = '0.6.3'
+    version = '0.6.4'
     author = 'Igor Korotchenkov'
     author_email = 'iDebugAll@gmail.com'
     base_url = 'nextbox-ui'

--- a/nextbox_ui_plugin/views.py
+++ b/nextbox_ui_plugin/views.py
@@ -301,7 +301,10 @@ def get_site_topology(site_id):
             "srcIfName": if_shortname(link.termination_a.name),
             "tgtIfName": if_shortname(link.termination_b.name)
         })
-        cable_path, endpoint = link.termination_a.trace()
+        trace_result = link.termination_a.trace()
+        if not trace_result:
+            continue
+        cable_path, *ignore = trace_result
         # identify segmented cable paths between end-devices
         if len(cable_path) < 2:
             continue

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ with open(path.join(top_level_directory, 'README.md'), encoding='utf-8') as file
 
 setup(
     name='nextbox_ui_plugin',
-    version='0.6.3',
+    version='0.6.4',
     url='https://github.com/iDebugAll/nextbox-ui-plugin',
-    download_url='https://github.com/iDebugAll/nextbox-ui-plugin/archive/v0.6.3.tar.gz',
+    download_url='https://github.com/iDebugAll/nextbox-ui-plugin/archive/v0.6.4.tar.gz',
     description='A topology visualization plugin for Netbox powered by NextUI Toolkit.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Cable trace method usage has been modified in Netbox 2.8.7 release.
It returns 3 values since 2.8.7. In earlier versions, there were 2 returned arguments.
Actual trace result which is used by the plugin is the first argument in the list.