### PR TITLE
Docker image fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM netboxcommunity/netbox:latest-ldap
+ARG FROM_IMAGE=netboxcommunity/netbox
+ARG FROM_TAG=latest-ldap
+ARG FROM=${FROM_IMAGE}:${FROM_TAG}
+FROM ${FROM}
 
 COPY ./nextbox_ui_plugin /source/nextbox-ui-plugin/nextbox_ui_plugin/
 COPY ./setup.py /source/nextbox-ui-plugin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY ./nextbox_ui_plugin /source/nextbox-ui-plugin/nextbox_ui_plugin/
 COPY ./setup.py /source/nextbox-ui-plugin/
 COPY ./MANIFEST.in /source/nextbox-ui-plugin/
 COPY ./README.md /source/nextbox-ui-plugin/
-RUN pip3 install nextbox-ui-plugin
+RUN pip3 install --no-cache-dir nextbox-ui-plugin


### PR DESCRIPTION
Two simple patches to remove the PyPi cache from the final image and allow easily building against other base images than the default one.