### PR TITLE
Make device name a link in a node tooltip

### DIFF
--- a/nextbox_ui_plugin/__init__.py
+++ b/nextbox_ui_plugin/__init__.py
@@ -4,7 +4,7 @@ class NextBoxUIConfig(PluginConfig):
     name = 'nextbox_ui_plugin'
     verbose_name = 'NextBox UI'
     description = 'A topology visualization plugin for Netbox powered by NextUI Toolkit.'
-    version = '0.7.0'
+    version = '0.7.1'
     author = 'Igor Korotchenkov'
     author_email = 'iDebugAll@gmail.com'
     base_url = 'nextbox-ui'

--- a/nextbox_ui_plugin/static/nextbox_ui_plugin/next_app.js
+++ b/nextbox_ui_plugin/static/nextbox_ui_plugin/next_app.js
@@ -115,7 +115,7 @@
                     content: [{
                         tag: 'a',
                         content: '{#node.model.name}',
-                        props: {"href": "{#node.model.dcimDeviceLink}"}
+                        props: {"href": "{#node.model.dcimDeviceLink}", "target": "_blank", "rel": "noopener noreferrer"}
                     }],
                     props: {
                         "style": "border-bottom: dotted 1px; font-size:90%; word-wrap:normal; color:#003688"

--- a/nextbox_ui_plugin/views.py
+++ b/nextbox_ui_plugin/views.py
@@ -238,6 +238,7 @@ def get_topology(nb_devices_qs):
     device_ids = [d.id for d in nb_devices_qs]
     for nb_device in nb_devices_qs:
         device_is_passive = False
+        device_url = nb_device.get_absolute_url()
         primary_ip = ''
         if nb_device.primary_ip:
             primary_ip = str(nb_device.primary_ip.address)
@@ -264,6 +265,7 @@ def get_topology(nb_devices_qs):
         topology_dict['nodes'].append({
             'id': nb_device.id,
             'name': nb_device.name,
+            'dcimDeviceLink': device_url,
             'primaryIP': primary_ip,
             'serial_number': nb_device.serial,
             'model': nb_device.device_type.model,

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ with open(path.join(top_level_directory, 'README.md'), encoding='utf-8') as file
 
 setup(
     name='nextbox_ui_plugin',
-    version='0.7.0',
+    version='0.7.1',
     url='https://github.com/iDebugAll/nextbox-ui-plugin',
-    download_url='https://github.com/iDebugAll/nextbox-ui-plugin/archive/v0.7.0.tar.gz',
+    download_url='https://github.com/iDebugAll/nextbox-ui-plugin/archive/v0.7.1.tar.gz',
     description='A topology visualization plugin for Netbox powered by NextUI Toolkit.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Device name in a node tooltip is now a link to NetBox DCIM device page.
Node tooltip appears on single left mouse button click on the topology node.
Click on the device name to jump to this device page. It will be opened in a new tab.