### PR TITLE
Save topology view

### DIFF
--- a/nextbox_ui_plugin/admin.py
+++ b/nextbox_ui_plugin/admin.py
@@ -4,4 +4,4 @@ from .models import SavedTopology
 
 @admin.register(SavedTopology)
 class SavedTopologyAdmin(admin.ModelAdmin):
-    list_display = ("user", "timestamp", "topology",)
+    list_display = ("name", "created_by", "timestamp", "topology",)

--- a/nextbox_ui_plugin/admin.py
+++ b/nextbox_ui_plugin/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from .models import SavedTopology
+
+
+@admin.register(SavedTopology)
+class SavedTopologyAdmin(admin.ModelAdmin):
+    list_display = ("user", "timestamp", "topology",)

--- a/nextbox_ui_plugin/api/__init__.py
+++ b/nextbox_ui_plugin/api/__init__.py
@@ -1,0 +1,1 @@
+"""REST API for NextBox-UI Plugin"""

--- a/nextbox_ui_plugin/api/serializers.py
+++ b/nextbox_ui_plugin/api/serializers.py
@@ -1,16 +1,20 @@
 from rest_framework import serializers
-from rest_framework.fields import CurrentUserDefault
 from nextbox_ui_plugin.models import SavedTopology
-from users.api.nested_serializers import NestedUserSerializer
 import datetime
 import json
 
+
 class SavedTopologySerializer(serializers.ModelSerializer):
+
+    created_by = serializers.CharField(read_only=True)
+    timestamp = serializers.DateTimeField(read_only=True)
 
     def to_internal_value(self, data):
         validated = {
+            'name': str(data.get('name').strip() or f"{self.context['request'].user} - {datetime.datetime.now()}"),
             'topology': json.loads(data.get('topology')),
-            'user': self.context['request'].user,
+            'layout_context': json.loads(data.get('layout_context')),
+            'created_by': self.context['request'].user,
             'timestamp': str(datetime.datetime.now())
         }
         return validated
@@ -18,5 +22,5 @@ class SavedTopologySerializer(serializers.ModelSerializer):
     class Meta:
         model = SavedTopology
         fields = [
-            "id", "topology", "user", "timestamp"
+            "id", "name", "topology", "layout_context", "created_by", "timestamp",
         ]

--- a/nextbox_ui_plugin/api/serializers.py
+++ b/nextbox_ui_plugin/api/serializers.py
@@ -1,0 +1,22 @@
+from rest_framework import serializers
+from rest_framework.fields import CurrentUserDefault
+from nextbox_ui_plugin.models import SavedTopology
+from users.api.nested_serializers import NestedUserSerializer
+import datetime
+import json
+
+class SavedTopologySerializer(serializers.ModelSerializer):
+
+    def to_internal_value(self, data):
+        validated = {
+            'topology': json.loads(data.get('topology')),
+            'user': self.context['request'].user,
+            'timestamp': str(datetime.datetime.now())
+        }
+        return validated
+
+    class Meta:
+        model = SavedTopology
+        fields = [
+            "id", "topology", "user", "timestamp"
+        ]

--- a/nextbox_ui_plugin/api/urls.py
+++ b/nextbox_ui_plugin/api/urls.py
@@ -1,0 +1,11 @@
+from rest_framework.routers import DefaultRouter
+from . import views
+
+
+router = DefaultRouter()
+router.APIRootView = views.NextBoxUIPluginRootView
+
+router.register(r'savedtopologies', views.SavedTopologyViewSet)
+
+app_name = "nextbox_ui_plugin-api"
+urlpatterns = router.urls

--- a/nextbox_ui_plugin/api/views.py
+++ b/nextbox_ui_plugin/api/views.py
@@ -1,0 +1,17 @@
+from rest_framework.routers import APIRootView
+from rest_framework.viewsets import ModelViewSet
+from nextbox_ui_plugin.models import SavedTopology
+from . import serializers
+
+
+class NextBoxUIPluginRootView(APIRootView):
+    """
+    NextBoxUI_plugin API root view
+    """
+    def get_view_name(self):
+        return 'NextBoxUI'
+
+
+class SavedTopologyViewSet(ModelViewSet):
+    queryset = SavedTopology.objects.all()
+    serializer_class = serializers.SavedTopologySerializer

--- a/nextbox_ui_plugin/forms.py
+++ b/nextbox_ui_plugin/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from utilities.forms import (
     BootstrapMixin, DynamicModelMultipleChoiceField,
 )
+from .models import SavedTopology
 from dcim.models import Device, Site, Region
 
 
@@ -26,4 +27,20 @@ class TopologyFilterForm(BootstrapMixin, forms.Form):
         required=False,
         to_field_name='id',
         null_option='None',
+    )
+
+
+class LoadSavedTopologyFilterForm(BootstrapMixin, forms.Form):
+
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop('user', None)
+        super(LoadSavedTopologyFilterForm, self).__init__(*args, **kwargs)
+        self.fields['saved_topology_id'].queryset = SavedTopology.objects.filter(created_by=user)
+
+    model = SavedTopology
+
+    saved_topology_id = forms.ModelChoiceField(
+        queryset=None,
+        to_field_name='id',
+        required=True
     )

--- a/nextbox_ui_plugin/migrations/0001_initial.py
+++ b/nextbox_ui_plugin/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('users', '0010_update_jsonfield'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SavedTopology',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False)),
+                ('topology', models.JSONField()),
+                ('timestamp', models.DateTimeField()),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='users.adminuser')),
+            ],
+        ),
+    ]

--- a/nextbox_ui_plugin/migrations/0001_initial.py
+++ b/nextbox_ui_plugin/migrations/0001_initial.py
@@ -15,9 +15,11 @@ class Migration(migrations.Migration):
             name='SavedTopology',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False)),
+                ('name', models.CharField(blank=True, max_length=100)),
                 ('topology', models.JSONField()),
+                ('layout_context', models.JSONField(blank=True, null=True)),
                 ('timestamp', models.DateTimeField()),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='users.adminuser')),
+                ('created_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='users.adminuser')),
             ],
         ),
     ]

--- a/nextbox_ui_plugin/models.py
+++ b/nextbox_ui_plugin/models.py
@@ -1,0 +1,19 @@
+from django.db import models
+from utilities.querysets import RestrictedQuerySet
+
+
+class SavedTopology(models.Model):
+
+    topology = models.JSONField()
+    user = models.ForeignKey(
+        to="users.AdminUser",
+        on_delete=models.CASCADE,
+        blank=False,
+        null=False,
+    )
+    timestamp = models.DateTimeField()
+
+    objects = RestrictedQuerySet.as_manager()
+
+    def __str__(self):
+        return str(self.timestamp)

--- a/nextbox_ui_plugin/models.py
+++ b/nextbox_ui_plugin/models.py
@@ -4,8 +4,10 @@ from utilities.querysets import RestrictedQuerySet
 
 class SavedTopology(models.Model):
 
+    name = models.CharField(max_length=100, blank=True)
     topology = models.JSONField()
-    user = models.ForeignKey(
+    layout_context = models.JSONField(null=True, blank=True)
+    created_by = models.ForeignKey(
         to="users.AdminUser",
         on_delete=models.CASCADE,
         blank=False,
@@ -16,4 +18,4 @@ class SavedTopology(models.Model):
     objects = RestrictedQuerySet.as_manager()
 
     def __str__(self):
-        return str(self.timestamp)
+        return str(self.name)

--- a/nextbox_ui_plugin/static/nextbox_ui_plugin/next_app.js
+++ b/nextbox_ui_plugin/static/nextbox_ui_plugin/next_app.js
@@ -347,6 +347,21 @@
         displayPassiveDevices = !displayPassiveDevices
     };
 
+    saveView = function (topoSaveURI, CSRFToken) {
+        $.ajax({
+            type: 'POST',
+            url: topoSaveURI,
+            data: {"topology": JSON.stringify(topo.data())},
+            headers: {"X-CSRFToken": CSRFToken},
+            success: function (response) {
+                console.log(response);
+            },
+            error: function (response) {
+                console.log(response)
+            }
+        })
+    };
+
     topo.on('topologyGenerated', function(){
         showHideUndonnected();
         showHidePassiveDevices();

--- a/nextbox_ui_plugin/static/nextbox_ui_plugin/next_app.js
+++ b/nextbox_ui_plugin/static/nextbox_ui_plugin/next_app.js
@@ -348,16 +348,36 @@
     };
 
     saveView = function (topoSaveURI, CSRFToken) {
+        var topoSaveName = document.getElementById('topoSaveName').value.trim();
+        var saveButton = document.getElementById('saveTopologyView');
+        var saveResultLabel = document.getElementById('saveResult');
+        saveButton.setAttribute('disabled', true);
+        saveResultLabel.setAttribute('innerHTML', 'Processing');
         $.ajax({
             type: 'POST',
             url: topoSaveURI,
-            data: {"topology": JSON.stringify(topo.data())},
-            headers: {"X-CSRFToken": CSRFToken},
+            data: {
+                'name': topoSaveName,
+                'topology': JSON.stringify(topo.data()),
+                'layout_context': JSON.stringify({
+                    'initialLayout': initialLayout,
+                    'displayUnconnected': !displayUnconnected,
+                    'undisplayedRoles': undisplayedRoles,
+                    'undisplayedDeviceTags': undisplayedDeviceTags,
+                    'displayPassiveDevices': !displayPassiveDevices,
+                    'displayLogicalMultiCableLinks': displayLogicalMultiCableLinks,
+                    'requestGET': requestGET,
+                })
+            },
+            headers: {'X-CSRFToken': CSRFToken},
             success: function (response) {
+                saveResultLabel.innerHTML = 'Success';
+                saveButton.removeAttribute('disabled');
                 console.log(response);
             },
             error: function (response) {
-                console.log(response)
+                saveResultLabel.innerHTML = 'Failed';
+                console.log(response);
             }
         })
     };
@@ -374,6 +394,9 @@
         });
         undisplayedDeviceTags.forEach(function(deviceTag){
             showHideDevicesByTag(deviceTag, false);
+        });
+        topologySavedData['nodes'].forEach(function(node){
+            topo.graph().getVertex(node['id']).position({'x': node.x, 'y': node.y});
         });
     });
 

--- a/nextbox_ui_plugin/templates/nextbox_ui_plugin/topology.html
+++ b/nextbox_ui_plugin/templates/nextbox_ui_plugin/topology.html
@@ -23,6 +23,7 @@
     </div>
     <input class="btn btn-primary" type="button" id="showHideUndonnectedButton" value="" onclick="return showHideUndonnectedButtonOnClick(this);" />
     <input class="btn btn-primary" type="button" id="showHidePassiveDevicesButton" value="" onclick="return showHidePassiveDevicesButtonOnClick(this);" />
+    <input class="btn btn-primary" type="button" id="saveTopologyView" value="Save Current View" onclick="return saveView(topoSaveURI, netbox_csrf_token);" />
     <div class="btn-group">
         <div class="dropdown">
             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -78,6 +79,7 @@
     var undisplayedDeviceTags = {{ undisplayed_device_tags|safe }};
     var topologyData = {{ source_data|safe }};
     var initialLayout = '{{ initial_layout|safe }}';
+    var topoSaveURI = '{% url 'plugins-api:nextbox_ui_plugin-api:savedtopology-list' %}';
     console.log(topologyData);
 </script>
 <script src="{% static 'nextbox_ui_plugin/next_app.js' %}"></script>

--- a/nextbox_ui_plugin/templates/nextbox_ui_plugin/topology.html
+++ b/nextbox_ui_plugin/templates/nextbox_ui_plugin/topology.html
@@ -15,6 +15,30 @@
 <div class="col-md-3 pull-right right-side-panel noprint" style="z-index: 2;">
     {% include 'inc/search_panel.html' %}
     {% block sidebar %}{% endblock %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <span class="mdi mdi-magnify" aria-hidden="true"></span>
+            <strong>Load Saved View</strong>
+        </div>
+        <div class="panel-body">
+            <form action="." method="get" class="form">
+                {% for field in load_saved_filter_form.visible_fields %}
+                    <div class="form-group">
+                            {{ field.label_tag }}
+                            {{ field }}
+                    </div>
+                {% endfor %}
+                <div class="text-right noprint">
+                    <button type="submit" class="btn btn-primary">
+                        <span class="mdi mdi-application-import" aria-hidden="true"></span> Apply
+                    </button>
+                    <a href="." class="btn btn-default">
+                        <span class="mdi mdi-close-thick" aria-hidden="true"></span> Clear
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
 </div>
 <div>
     <div class="btn-group">
@@ -23,7 +47,6 @@
     </div>
     <input class="btn btn-primary" type="button" id="showHideUndonnectedButton" value="" onclick="return showHideUndonnectedButtonOnClick(this);" />
     <input class="btn btn-primary" type="button" id="showHidePassiveDevicesButton" value="" onclick="return showHidePassiveDevicesButtonOnClick(this);" />
-    <input class="btn btn-primary" type="button" id="saveTopologyView" value="Save Current View" onclick="return saveView(topoSaveURI, netbox_csrf_token);" />
     <div class="btn-group">
         <div class="dropdown">
             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -54,6 +77,23 @@
             </div>
         </div>
     </div>
+    <div class="btn-group">
+        <div class="dropdown">
+            <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Save Current View
+            </button>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                <h6 class="dropdown-header">Saved View Name:</h6>
+                <div style="margin-bottom: 5px; margin-left: 2px; margin-right: 2px;">
+                    <input type="text" id="topoSaveName" name="topoSaveName"></input>
+                </div>
+                <div style="margin-left: 2px; margin-right: 2px;">
+                    <label class="control-label col-sm-6 pull-left" for="saveTopologyView" id="saveResult" style="margin-top: 7px; margin-left:4px;"></label>
+                    <input class="btn btn-primary pull-right" type="button" id="saveTopologyView" value="Submit" onclick="return saveView(topoSaveURI, netbox_csrf_token);" />
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 <div class="row noprint" style="z-index: 1;">
     <div class="col-lg-3" style="z-index: 1;">
@@ -78,7 +118,9 @@
     var undisplayedRoles = {{ undisplayed_roles|safe }};
     var undisplayedDeviceTags = {{ undisplayed_device_tags|safe }};
     var topologyData = {{ source_data|safe }};
+    var topologySavedData = {{ source_data|safe }};
     var initialLayout = '{{ initial_layout|safe }}';
+    var requestGET = {{ requestGET|safe }};
     var topoSaveURI = '{% url 'plugins-api:nextbox_ui_plugin-api:savedtopology-list' %}';
     console.log(topologyData);
 </script>


### PR DESCRIPTION
A Topology Viewer page (`plugins/nextbox-ui/topology/`) now allows you to save a current layout to the database.
A saved topology is a *"snapshot"* of the topology state on the screen with all associated attributes.
A saved topology can then be loaded from the Topology Viewer page. Overall device layout and their relative coordinates will be preserved. General plugin Hide/Display controls are also preserved on the view save/load.
Device and link changes taken between save and load actions are not currently considered. Load Saved View shows a topology state in the past as is.
Tracking changes is a matter of further development.