### PR TITLE
Add ghcr.io support with modified readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: ci
+
+# Only triggering of this branches
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  package:
+    name: Build image container, store in ghcr.io
+    runs-on: ubuntu-18.04 # ATTN - if change, needs also updated `.actrc`
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+      - name: Package container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -230,17 +230,11 @@ sudo systemctl restart netbox
 # Installation with Docker
 The Plugin may be installed in a Netbox Docker deployment. 
 The package contains a Dockerfile for [Netbox-Community Docker](https://github.com/netbox-community/netbox-docker) extension. Latest-LDAP version is used by default as a source.<br/>
-Download the Plugin and build from the source:
-```
-$ git clone https://github.com/iDebugAll/nextbox-ui-plugin
-$ cd nextbox-ui-plugin
-$ docker build -t netbox-custom .
-```
 Update a netbox image name in **docker-compose.yml** in a Netbox Community Docker project root:
 ```yaml
 services:
   netbox: &netbox
-    image: netbox-custom:latest
+    image: ghrc.io/idebugall/nextbox-ui-plugin:latest
 ```
 Update a **configuration.py**. It is stored in netbox-docker/configuration/ by default. Update or add PLUGINS parameter and PLUGINS_CONFIG parameter as described above.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Update a netbox image name in **docker-compose.yml** in a Netbox Community Docke
 ```yaml
 services:
   netbox: &netbox
-    image: ghrc.io/idebugall/nextbox-ui-plugin:latest
+    image: ghcr.io/idebugall/nextbox-ui-plugin:latest
 ```
 Update a **configuration.py**. It is stored in netbox-docker/configuration/ by default. Update or add PLUGINS parameter and PLUGINS_CONFIG parameter as described above.
 


### PR DESCRIPTION
Allows user in there kubernetes setup to use you image direct from Github Package registry. 
Check this out: [https://artifacthub.io/packages/helm/bootc/netbox/](https://artifacthub.io/packages/helm/bootc/netbox/)