### PR TITLE
use new version identifier from netbox - fixes #163

### DIFF
--- a/nextbox_ui_plugin/__init__.py
+++ b/nextbox_ui_plugin/__init__.py
@@ -1,6 +1,6 @@
 from packaging import version
 from django.conf import settings
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+NETBOX_CURRENT_VERSION = version.parse(settings.RELEASE.version)
 
 if NETBOX_CURRENT_VERSION >= version.parse("4.0.0"):
     from netbox.plugins import PluginConfig

--- a/nextbox_ui_plugin/migrations/0001_initial.py
+++ b/nextbox_ui_plugin/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import connection
 from django.conf import settings
 from packaging import version
 
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+NETBOX_CURRENT_VERSION = version.parse(settings.RELEASE.version)
 
 def get_user_model():
     if NETBOX_CURRENT_VERSION >= version.parse("4.0.0"):

--- a/nextbox_ui_plugin/models.py
+++ b/nextbox_ui_plugin/models.py
@@ -3,7 +3,7 @@ from utilities.querysets import RestrictedQuerySet
 from django.conf import settings
 from packaging import version
 
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+NETBOX_CURRENT_VERSION = version.parse(settings.RELEASE.version)
 
 def get_user_model():
     if NETBOX_CURRENT_VERSION >= version.parse("4.0.0"):

--- a/nextbox_ui_plugin/views.py
+++ b/nextbox_ui_plugin/views.py
@@ -14,7 +14,7 @@ import json
 import re
 
 
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+NETBOX_CURRENT_VERSION = version.parse(settings.RELEASE.version)
 
 # Default NeXt UI icons
 SUPPORTED_ICONS = {


### PR DESCRIPTION
Fix #163 

Verified with Netbox version `4.2.5-Docker-3.2.0`

Derived from netbox-community/netbox-topology-views#608